### PR TITLE
installing setuptools manually to ensure latest version. pip installing ...

### DIFF
--- a/etc/install/install.sh
+++ b/etc/install/install.sh
@@ -26,7 +26,9 @@ export LC_ALL=en_GB.UTF-8
 # Install essential packages from Apt
 apt-get update -y
 # Python dev packages
-apt-get install -y build-essential python python-dev python-setuptools python-pip
+apt-get install -y build-essential python python-dev
+# python-setuptools being installed manually
+wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py -O - | python
 # Dependencies for image processing with PIL
 apt-get install -y libjpeg62-dev zlib1g-dev libfreetype6-dev liblcms1-dev
 # Git (we'd rather avoid people keeping credentials for git commits in the repo, but sometimes we need it for pip requirements that aren't in PyPI)
@@ -44,7 +46,7 @@ if ! command -v pip; then
     easy_install -U pip
 fi
 if [[ ! -f /usr/local/bin/virtualenv ]]; then
-    easy_install virtualenv virtualenvwrapper stevedore virtualenv-clone
+    pip install virtualenv virtualenvwrapper stevedore virtualenv-clone
 fi
 
 # bash environment global setup


### PR DESCRIPTION
...stevedore to avoid install problems

I was hitting this problem when attempting to use the template with a precise64 image: https://bitbucket.org/dhellmann/virtualenvwrapper/issue/199/packaging-problem-unable-to-use

Not totally sure what the problem is, but as a respondent mentions, using pip to install fixes the issue.

Also, the setuptools package that apt was downloading was 0.6. The current wheel support in pip requires >= 0.8,   so I manually installed the more current version.  
